### PR TITLE
enhance splunk query builder

### DIFF
--- a/pkg/log/client/field_remapping.go
+++ b/pkg/log/client/field_remapping.go
@@ -1,0 +1,15 @@
+package client
+
+import "github.com/berlingoqc/logviewer/pkg/ty"
+
+type FieldRemapping struct{}
+
+func (m FieldRemapping) RemapFieldSet(fields ty.UniSet[string]) ty.UniSet[string] {
+
+	return fields
+}
+
+func (m FieldRemapping) RemapField(field ty.MI) ty.MI {
+
+	return field
+}

--- a/pkg/log/client/operator/operator.go
+++ b/pkg/log/client/operator/operator.go
@@ -1,0 +1,9 @@
+package operator
+
+const (
+	Equals   = "equals"
+	Match    = "match"
+	Wildcard = "wildcard"
+	Exists   = "exists"
+	Regex    = "regex"
+)

--- a/pkg/log/impl/splunk/logclient/mapper_test.go
+++ b/pkg/log/impl/splunk/logclient/mapper_test.go
@@ -4,27 +4,124 @@ import (
 	"testing"
 
 	"github.com/berlingoqc/logviewer/pkg/log/client"
+	"github.com/berlingoqc/logviewer/pkg/log/client/operator"
 	"github.com/berlingoqc/logviewer/pkg/ty"
 	"github.com/stretchr/testify/assert"
 )
 
 func TestSearchRequest(t *testing.T) {
 
-	logSearch := client.LogSearch{
-		Fields:  ty.MS{},
-		Options: ty.MI{},
-	}
-	logSearch.Range.Gte.S("24h@h")
-	logSearch.Range.Lte.S("now")
+	t.Run("simple search with index and one equals condition", func(t *testing.T) {
+		logSearch := &client.LogSearch{
+			Fields:          ty.MS{"application_name": "wq.services.pet"},
+			FieldsCondition: ty.MS{},
+			Options:         ty.MI{"index": "nonprod"},
+		}
+		logSearch.Range.Gte.S("24h@h")
+		logSearch.Range.Lte.S("now")
 
-	logSearch.Fields["application_name"] = "wq.services.pet"
-	logSearch.Fields["trace_id"] = "1234"
-	logSearch.Options["index"] = "nonprod"
+		requestBodyFields, err := getSearchRequest(logSearch)
+		assert.NoError(t, err)
+		assert.Equal(t, `index=nonprod application_name="wq.services.pet"`, requestBodyFields["search"])
+	})
 
-	requestBodyFields, err := getSearchRequest(&logSearch)
-	if err != nil {
-		t.Error(err)
-	}
+	t.Run("search with multiple equals conditions", func(t *testing.T) {
+		logSearch := &client.LogSearch{
+			Fields:          ty.MS{"application_name": "wq.services.pet", "trace_id": "1234"},
+			FieldsCondition: ty.MS{},
+			Options:         ty.MI{"index": "nonprod"},
+		}
+		logSearch.Range.Gte.S("24h@h")
+		logSearch.Range.Lte.S("now")
 
-	assert.Equal(t, `index=nonprod+application_name="wq.services.pet"&trace_id="1234"`, requestBodyFields["search"])
+		requestBodyFields, err := getSearchRequest(logSearch)
+		assert.NoError(t, err)
+		assert.Contains(t, requestBodyFields["search"], `index=nonprod`)
+		assert.Contains(t, requestBodyFields["search"], `application_name="wq.services.pet"`)
+		assert.Contains(t, requestBodyFields["search"], `trace_id="1234"`)
+	})
+
+	t.Run("search with wildcard condition", func(t *testing.T) {
+		logSearch := &client.LogSearch{
+			Fields:          ty.MS{"application_name": "wq.services"},
+			FieldsCondition: ty.MS{"application_name": operator.Wildcard},
+			Options:         ty.MI{"index": "nonprod"},
+		}
+		logSearch.Range.Gte.S("24h@h")
+		logSearch.Range.Lte.S("now")
+
+		requestBodyFields, err := getSearchRequest(logSearch)
+		assert.NoError(t, err)
+		assert.Equal(t, `index=nonprod application_name=wq.services*`, requestBodyFields["search"])
+	})
+
+	t.Run("search with exists condition", func(t *testing.T) {
+		logSearch := &client.LogSearch{
+			Fields:          ty.MS{"trace_id": ""},
+			FieldsCondition: ty.MS{"trace_id": operator.Exists},
+			Options:         ty.MI{"index": "nonprod"},
+		}
+		logSearch.Range.Gte.S("24h@h")
+		logSearch.Range.Lte.S("now")
+
+		requestBodyFields, err := getSearchRequest(logSearch)
+		assert.NoError(t, err)
+		assert.Equal(t, `index=nonprod trace_id=*`, requestBodyFields["search"])
+	})
+
+	t.Run("search with regex condition", func(t *testing.T) {
+		logSearch := &client.LogSearch{
+			Fields:          ty.MS{"message": "(error|fail)"},
+			FieldsCondition: ty.MS{"message": operator.Regex},
+			Options:         ty.MI{"index": "nonprod"},
+		}
+		logSearch.Range.Gte.S("24h@h")
+		logSearch.Range.Lte.S("now")
+
+		requestBodyFields, err := getSearchRequest(logSearch)
+		assert.NoError(t, err)
+		assert.Equal(t, `index=nonprod | regex message="(error|fail)"`, requestBodyFields["search"])
+	})
+
+	t.Run("complex search with multiple operators", func(t *testing.T) {
+		logSearch := &client.LogSearch{
+			Fields: ty.MS{
+				"application_name": "wq.services.pet",
+				"http_method":      "GET",
+				"message":          "(error|fail)",
+				"trace_id":         "",
+			},
+			FieldsCondition: ty.MS{
+				"application_name": operator.Wildcard,
+				"http_method":      operator.Equals,
+				"message":          operator.Regex,
+				"trace_id":         operator.Exists,
+			},
+			Options: ty.MI{"index": "nonprod"},
+		}
+		logSearch.Range.Gte.S("24h@h")
+		logSearch.Range.Lte.S("now")
+
+		requestBodyFields, err := getSearchRequest(logSearch)
+		assert.NoError(t, err)
+		assert.Contains(t, requestBodyFields["search"], `index=nonprod`)
+		assert.Contains(t, requestBodyFields["search"], `application_name=wq.services.pet*`)
+		assert.Contains(t, requestBodyFields["search"], `http_method="GET"`)
+		assert.Contains(t, requestBodyFields["search"], `trace_id=*`)
+		assert.Contains(t, requestBodyFields["search"], `| regex message="(error|fail)"`)
+	})
+
+	t.Run("search with value containing spaces", func(t *testing.T) {
+		logSearch := &client.LogSearch{
+			Fields:          ty.MS{"message": "this is a test"},
+			FieldsCondition: ty.MS{},
+			Options:         ty.MI{"index": "nonprod"},
+		}
+		logSearch.Range.Gte.S("24h@h")
+		logSearch.Range.Lte.S("now")
+
+		requestBodyFields, err := getSearchRequest(logSearch)
+		assert.NoError(t, err)
+		assert.Equal(t, `index=nonprod message="this is a test"`, requestBodyFields["search"])
+	})
 }

--- a/pkg/ty/map.go
+++ b/pkg/ty/map.go
@@ -30,6 +30,14 @@ func (mi MI) GetString(key string) string {
 	return ""
 }
 
+func (mi MI) GetStringOk(key string) (string, bool) {
+	v, ok := mi[key]
+	if ok {
+		return v.(string), ok
+	}
+	return "", false
+}
+
 func (mi MI) GetMS(key string) MS {
 	if v, b := mi[key]; b {
 		return v.(MS)


### PR DESCRIPTION
Task: Enhance Splunk Query Mapping

User Story:

As a logviewer user, I want to perform advanced queries on my Splunk instance using the same familiar filter operators (equals, wildcard, regex, exists, etc.) that I use for other log sources, so that I can have a consistent and powerful debugging experience across all my backends.
Acceptance Criteria

    The getSearchRequest function in pkg/log/impl/splunk/logclient/mapper.go is refactored to correctly translate LogSearch into a valid Splunk Processing Language (SPL) query.

    The generated SPL query must support the following operators from FieldsCondition:

        equals / match (should produce field="value")

        wildcard (should produce field=value* or similar)

        exists (should produce field=*)

        regex (should produce | regex field="value")

    The implementation correctly handles multiple field conditions, joining them with spaces (implicit AND).

    Values in the SPL query are properly quoted to handle spaces and special characters.

    The index from LogSearch.Options is correctly included in the query (index=my_index).

    Unit tests in pkg/log/impl/splunk/logclient/mapper_test.go are updated to cover all supported operators and edge cases.

💻 Technical Details & Implementation Steps
1. Refactor getSearchRequest in mapper.go

The primary file to modify is pkg/log/impl/splunk/logclient/mapper.go.

The current implementation incorrectly uses + and & to join search terms. This needs to be completely replaced with logic that builds a valid SPL query string.

Implementation Guide:

    Initialize a strings.Builder: This is the most efficient way to build the query string.

    Handle the index: If logSearch.Options["index"] exists, prepend index=<index_value> to the query string. This is a common and efficient way to start a Splunk search.

    Iterate over logSearch.Fields: For each key-value pair, do the following:

        Look up the corresponding operator in logSearch.FieldsCondition. If no operator is specified, default to equals.

        Append a space to the strings.Builder if it's not empty.

        Use a switch statement on the operator to generate the correct SPL syntax.

    Handle Quoting: Ensure that all values are properly quoted to prevent errors with spaces or special characters. A simple fmt.Sprintf(%s="%s", key, value) is a good starting point.

    Handle regex: The regex operator in Splunk is a command that runs after the initial search. You'll need a separate strings.Builder for these commands. After processing all other fields, if the regex builder is not empty, append its content to the main query string, prefixed with a pipe (|).

2. Update Unit Tests in mapper_test.go

The file pkg/log/impl/splunk/logclient/mapper_test.go needs to be updated to validate the new query generation logic.

Test Cases to Add:

    A simple search with an index and one equals condition.

    A search with multiple equals conditions.

    A search with a wildcard condition.

    A search with an exists condition.

    A search with a regex condition.

    A complex search that combines multiple different operators.

    A test case to ensure that values with spaces are correctly quoted.

⛔ Out of Scope

    Support for advanced boolean logic (OR, NOT). The default behavior will be an implicit AND between all conditions.

    Support for numerical operators (gt, lt, etc.). This can be added in a future task.

    Support for complex SPL commands beyond regex (e.g., stats, eval, table).

✅ Definition of Done

    [ ] The getSearchRequest function in mapper.go is fully refactored.

    [ ] The implementation correctly handles equals, wildcard, exists, and regex operators.

    [ ] Unit tests in mapper_test.go are updated with comprehensive test cases for the new logic.

    [ ] All existing tests are still passing.

    [ ] The code has been reviewed and approved by another team member.